### PR TITLE
Fix bug in get_rustc_version()

### DIFF
--- a/src/rustbininfo/info/compiler.py
+++ b/src/rustbininfo/info/compiler.py
@@ -52,7 +52,7 @@ def get_rustc_version(target: pathlib.Path) -> Tuple[Optional[str], Optional[str
     version = _get_version_from_commit(commit)
     if version is None:
         log.debug("No tag matching this commit, getting latest version")
-        return _get_latest_rustc_version()
+        return (commit, _get_latest_rustc_version())
 
     log.debug(f"Found tag {version}")
     return (commit, version)


### PR DESCRIPTION
Return commit hash and latest rustc version if commit hash does not correspond to a release tag. 

Fixes the tool for ``f00ed06a1d402ecf760ec92f3280ef6c09e76036854abacadcac9311706ed97d``, as well as presumably any other rust binaries with a non-tagged commit hash.