### PR TITLE
Allow the constructor for TargetRustInfo to allow Optional[str] instead of [str] for rustc_version and rustc_commit_hash

### DIFF
--- a/src/rustbininfo/info/models/info.py
+++ b/src/rustbininfo/info/models/info.py
@@ -66,8 +66,8 @@ def imphash(dependencies: List[Crate]):
 
 
 class TargetRustInfo(BaseModel):
-    rustc_version: str
-    rustc_commit_hash: str
+    rustc_version: Optional[str]
+    rustc_commit_hash: Optional[str]
     dependencies: List[Crate]
     rust_dependencies_imphash: str
     guessed_toolchain: Optional[str] = None


### PR DESCRIPTION
Rust developers can set the Rust standard library path to a different path that does not contain the rustc commit ID. When parsing a binary of this sort, the `get_rustc_commit` function attempts to return a tuple of (None, None). 

When this tuple is returned, Pydantic is unhappy with this result, as the constructor for TargetRustInfo expects these fields to be a string, which causes an error.

This commit changes the type of the `rustc_version` and `rustc_commit_hash` variables to allow for None types. This is useful when analyzing malware samples without a rustc commit hash in the library path, allowing for crate information to still be displayed.