### PR TITLE
Add nightly rustc version check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rustbininfo"
-version = "0.5.2"
+version = "0.5.3"
 description = "Get information about stripped rust executables"
 authors = ["Nofix <16479266+N0fix@users.noreply.github.com>"]
 readme = "README.md"

--- a/src/rustbininfo/info/models/github_api.py
+++ b/src/rustbininfo/info/models/github_api.py
@@ -1,0 +1,14 @@
+from typing import List, Optional
+from pydantic import BaseModel
+
+
+class Milestone(BaseModel):
+    title: Optional[str]
+
+
+class GitHubIssue(BaseModel):
+    milestone: Optional[Milestone]
+
+
+class GitHubResponse(BaseModel):
+    items: List[GitHubIssue]


### PR DESCRIPTION
If the `rustc` commit hash cannot be found at `https://github.com/rust-lang/rust/branch_commits/{commit}`, there is a high chance that the binary was built with a nightly (or custom though this is less likely) toolchain. So I added an extra check for this.

It properly identifies the version for a binary I built with `1.84.0-nightly`:

```
$ pwd
/home/gemesa/git-repos/tmp/rust2
$ rustc --version
rustc 1.84.0-nightly (e7c0d2750 2024-10-15)
```

```
$ rbi -f /home/gemesa/git-repos/tmp/rust2/target/debug/rust2
TargetRustInfo(
    rustc_version='1.84.0-nightly',
    rustc_commit_hash='e7c0d2750726c1f08b1de6956248ec78c4a97af6',
    dependencies=[
        Crate(
            name='addr2line',
            version='0.22.0',
            features=['default', 'rustc-dep-of-std', 'std', 'std-object'],
            repository='https://github.com/gimli-rs/addr2line'
        ),
        Crate(
            name='gimli',
            version='0.29.0',
            features=[
                'default',
                'endian-reader',
                'fallible-iterator',
                'read',
                'read-all',
                'read-core',
                'rustc-dep-of-std',
                'std',
                'write'
            ],
            repository='https://github.com/gimli-rs/gimli'
        ),
        Crate(
            name='miniz_oxide',
            version='0.7.4',
            features=['default', 'rustc-dep-of-std', 'simd', 'std', 'with-alloc'],
            repository='https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide'
        )
    ],
    rust_dependencies_imphash='3ffc8df6f53016073077e199147c697f',
    guessed_toolchain=None
)
```