### PR TITLE
Improve dependency guesser

### DIFF
--- a/src/rustbininfo/info/dependencies.py
+++ b/src/rustbininfo/info/dependencies.py
@@ -8,15 +8,17 @@ from .models.crate import Crate
 
 def _guess_dependencies(content: bytes) -> Set:
     regexes = [
-        rb"index.crates.io.[^\\\/]+.([^\\\/]+)",
-        rb"registry.src.[^\\\/]+.([^\\\/]+)",
-        rb"rust.deps.([^\\\/]+)",
+        # "/index.crates.io-6f17d22bba15001f/rayon-core-1.12.1/src/job.rs
+        rb"index.crates.io.[^\\\/]+.([a-zA-z0-9_-]+-[a-zA-z0-9._-]+)",
+        # \registry\src\github.com-1ecc6299db9ec823\aho-corasick-0.7.15\src\ahocorasick.rs
+        rb"registry.src.[^\\\/]+.([a-zA-z0-9_-]+-[a-zA-z0-9._-]+)",
+        # /rust/deps\indexmap-2.2.6\src\map\core.rs
+        rb"rust.deps.([a-zA-z0-9_-]+-[a-zA-z0-9._-]+)",
     ]
-    result = []
+    result = set()
     for reg in regexes:
         res = re.findall(reg, content)
-        if len(set(res)) > len(result):
-            result = set(res)
+        result.update(res)
 
     return result
 


### PR DESCRIPTION
In the current implementation there are cases where the dependency quesser does not list all of the dependencies.

For example, I created a simple project using the `rayon` crate where the following dependencies are listed by `cargo`:

```
$ cargo tree
rust-rayon v0.1.0 (/home/gemesa/git-repos/tmp/rust-rayon)
└── rayon v1.10.0
    ├── either v1.13.0
    └── rayon-core v1.12.1
        ├── crossbeam-deque v0.8.5
        │   ├── crossbeam-epoch v0.9.18
        │   │   └── crossbeam-utils v0.8.20
        │   └── crossbeam-utils v0.8.20
        └── crossbeam-utils v0.8.20
```

But when I run `rbi` none of them are listed:

```
$ poetry run rbi -f ~/git-repos/tmp/rust-rayon/target/debug/rust-rayon
TargetRustInfo(
    rustc_version='1.82.0',
    rustc_commit_hash='f6e511eec7342f59a25f7c0534f1dbea00d01b14',
    dependencies=[
        Crate(
            name='addr2line',
            version='0.22.0',
            features=['default', 'rustc-dep-of-std', 'std', 'std-object'],
            repository='https://github.com/gimli-rs/addr2line'
        ),
        Crate(
            name='compiler_builtins',
            version='0.1.123',
            features=[
                'c',
                'compiler-builtins',
                'default',
                'mangled-names',
                'mem',
                'no-asm',
                'no-f16-f128',
                'public-test-deps',
                'rustc-dep-of-std'
            ],
            repository='https://github.com/rust-lang/compiler-builtins'
        ),
        Crate(
            name='gimli',
            version='0.29.0',
            features=[
                'default',
                'endian-reader',
                'fallible-iterator',
                'read',
                'read-all',
                'read-core',
                'rustc-dep-of-std',
                'std',
                'write'
            ],
            repository='https://github.com/gimli-rs/gimli'
        ),
        Crate(
            name='hashbrown',
            version='0.14.5',
            features=['default', 'inline-more', 'nightly', 'raw', 'rustc-dep-of-std', 'rustc-internal-api'],
            repository='https://github.com/rust-lang/hashbrown'
        ),
        Crate(
            name='libc',
            version='0.2.158',
            features=['align', 'const-extern-fn', 'default', 'extra_traits', 'rustc-dep-of-std', 'std', 'use_std'],
            repository='https://github.com/rust-lang/libc'
        ),
        Crate(
            name='memchr',
            version='2.5.0',
            features=['default', 'rustc-dep-of-std', 'std', 'use_std'],
            repository='https://github.com/BurntSushi/memchr'
        ),
        Crate(
            name='miniz_oxide',
            version='0.7.4',
            features=['default', 'rustc-dep-of-std', 'simd', 'std', 'with-alloc'],
            repository='https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide'
        ),
        Crate(
            name='object',
            version='0.36.2',
            features=[
                'all',
                'archive',
                'build',
                'build_core',
                'cargo-all',
                'coff',
                'compression',
                'default',
                'doc',
                'elf',
                'macho',
                'pe',
                'read',
                'read_core',
                'rustc-dep-of-std',
                'std',
                'unaligned',
                'unstable',
                'unstable-all',
                'wasm',
                'write',
                'write_core',
                'write_std',
                'xcoff'
            ],
            repository='https://github.com/gimli-rs/object'
        )
    ],
    rust_dependencies_imphash='11241b24a7fa004a2bf3451f6f2c1d16',
    guessed_toolchain=None
)

```

The issue is that in `_guess_dependencies()` the results are not merged into one set, instead only the longest one is used:

```python
    for reg in regexes:
        res = re.findall(reg, content)
        if len(set(res)) > len(result):
            result = set(res)
```

I also improved the regex patterns because they were matching strings we dont want. I noticed this after merging the 3 results into one. For example, if I print the results returned by `re.findall()` we can see unwanted strings like this:

```
b'addr2line-0.22.0'
b'object-0.36.2'
b'compiler_builtins-0.1.123\x00'
b'memchr-2.5.0'
b'memchr-2.5.0\x00_ZN4core3ptr9const_ptr33_$LT$impl$u20$... (I cut the rest)'
b'hashbrown-0.14.5'
b'rustc-demangle-0.1.24'
b'gimli-0.29.0'
b'libc-0.2.158'
b's'
b'compiler_builtins-0.1.123'
b'miniz_oxide-0.7.4'
b'hashbrown-0.14.5\x00_ZN4core3fmt9Arguments9new_const17... (I cut the rest)'
```

Now with my changes this is the output which looks good IMO:

```
TargetRustInfo(
    rustc_version='1.82.0',
    rustc_commit_hash='f6e511eec7342f59a25f7c0534f1dbea00d01b14',
    dependencies=[
        Crate(
            name='addr2line',
            version='0.22.0',
            features=['default', 'rustc-dep-of-std', 'std', 'std-object'],
            repository='https://github.com/gimli-rs/addr2line'
        ),
        Crate(
            name='compiler_builtins',
            version='0.1.123',
            features=[
                'c',
                'compiler-builtins',
                'default',
                'mangled-names',
                'mem',
                'no-asm',
                'no-f16-f128',
                'public-test-deps',
                'rustc-dep-of-std'
            ],
            repository='https://github.com/rust-lang/compiler-builtins'
        ),
        Crate(
            name='crossbeam-deque',
            version='0.8.5',
            features=['default', 'std'],
            repository='https://github.com/crossbeam-rs/crossbeam'
        ),
        Crate(
            name='crossbeam-epoch',
            version='0.9.18',
            features=['alloc', 'default', 'loom', 'nightly', 'std'],
            repository='https://github.com/crossbeam-rs/crossbeam'
        ),
        Crate(
            name='crossbeam-utils',
            version='0.8.20',
            features=['default', 'nightly', 'std'],
            repository='https://github.com/crossbeam-rs/crossbeam'
        ),
        Crate(
            name='gimli',
            version='0.29.0',
            features=[
                'default',
                'endian-reader',
                'fallible-iterator',
                'read',
                'read-all',
                'read-core',
                'rustc-dep-of-std',
                'std',
                'write'
            ],
            repository='https://github.com/gimli-rs/gimli'
        ),
        Crate(
            name='hashbrown',
            version='0.14.5',
            features=['default', 'inline-more', 'nightly', 'raw', 'rustc-dep-of-std', 'rustc-internal-api'],
            repository='https://github.com/rust-lang/hashbrown'
        ),
        Crate(
            name='libc',
            version='0.2.158',
            features=['align', 'const-extern-fn', 'default', 'extra_traits', 'rustc-dep-of-std', 'std', 'use_std'],
            repository='https://github.com/rust-lang/libc'
        ),
        Crate(
            name='memchr',
            version='2.5.0',
            features=['default', 'rustc-dep-of-std', 'std', 'use_std'],
            repository='https://github.com/BurntSushi/memchr'
        ),
        Crate(
            name='miniz_oxide',
            version='0.7.4',
            features=['default', 'rustc-dep-of-std', 'simd', 'std', 'with-alloc'],
            repository='https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide'
        ),
        Crate(
            name='object',
            version='0.36.2',
            features=[
                'all',
                'archive',
                'build',
                'build_core',
                'cargo-all',
                'coff',
                'compression',
                'default',
                'doc',
                'elf',
                'macho',
                'pe',
                'read',
                'read_core',
                'rustc-dep-of-std',
                'std',
                'unaligned',
                'unstable',
                'unstable-all',
                'wasm',
                'write',
                'write_core',
                'write_std',
                'xcoff'
            ],
            repository='https://github.com/gimli-rs/object'
        ),
        Crate(
            name='rayon',
            version='1.10.0',
            features=['web_spin_lock'],
            repository='https://github.com/rayon-rs/rayon'
        ),
        Crate(
            name='rayon-core',
            version='1.12.1',
            features=['web_spin_lock'],
            repository='https://github.com/rayon-rs/rayon'
        )
    ],
    rust_dependencies_imphash='48b9bcf05a6753e70f678a2c9feb79b3',
    guessed_toolchain=None
)
```

I also ran your tests to make sure nothing breaks:

```
$ pytest -s
================================================ test session starts =================================================
platform linux -- Python 3.13.0, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/gemesa/git-repos/rustbininfo
configfile: pyproject.toml
collected 5 items                                                                                                    

tests/test_download.py .
tests/test_info.py ...
tests/test_timestamp_guess.py .

================================================= 5 passed in 2.71s ==================================================

```