### PR TITLE
Return None for unknown Rustc versions

### DIFF
--- a/src/rustbininfo/info/compiler.py
+++ b/src/rustbininfo/info/compiler.py
@@ -71,8 +71,8 @@ def get_rustc_version(target: pathlib.Path) -> Tuple[Optional[str], Optional[str
         log.debug("No tag matching this commit, getting milestone version")
         version = _get_nightly_version_from_commit(commit)
         if version is None:
-            log.debug("No milestone matching this commit, getting latest version")
-            return (commit, _get_latest_rustc_version())
+            log.debug("No milestone matching this commit, unknown version")
+            return (commit, None)
 
     log.debug(f"Found tag/milestone {version}")
     return (commit, version)


### PR DESCRIPTION
I think `rbi` should not return the latest `rustc` version when it cannot determine the actual version. This can be misleading. Some binaries might be built with custom (non-community) Rust toolchains such as [Ferrocene](https://github.com/ferrocene/ferrocene), [HighTec RDP](https://hightec-rt.com/rust) or any other modified toolchains.

What do you think?

```
$ rbi -f ~/git-repos/tmp/rust-rayon/rust-rayon-unknown
TargetRustInfo(
    rustc_version=None,
    rustc_commit_hash='g6e511eec7342f59a25f7c0534f1dbea00d01b14',
    dependencies=[
        Crate(
            name='crossbeam-deque',
            version='0.8.5',
            features=['default', 'std'],
            repository='https://github.com/crossbeam-rs/crossbeam'
        ),
        Crate(
            name='crossbeam-epoch',
            version='0.9.18',
            features=['alloc', 'default', 'loom', 'nightly', 'std'],
            repository='https://github.com/crossbeam-rs/crossbeam'
        ),
        Crate(
            name='rayon',
            version='1.10.0',
            features=['web_spin_lock'],
            repository='https://github.com/rayon-rs/rayon'
        ),
        Crate(
            name='rayon-core',
            version='1.12.1',
            features=['web_spin_lock'],
            repository='https://github.com/rayon-rs/rayon'
        )
    ],
    rust_dependencies_imphash='448bbc16eb0dc31aa085c896d6ba2585',
    guessed_toolchain=None
)
```