### PR TITLE
Extend rustc version check

### DIFF
--- a/src/rustbininfo/info/compiler.py
+++ b/src/rustbininfo/info/compiler.py
@@ -31,6 +31,19 @@ def get_rustc_commit(target: pathlib.Path) -> str | None:
         return res.group(1).decode()
 
 
+def _get_version_from_comment(target: pathlib.Path) -> Optional[str]:
+    data = open(target, "rb").read()
+    # .comment section:
+    # rustc version 1.85.0-nightly
+    # rustc version 1.83.0
+    res = re.search(b"rustc\s*version\s*([a-zA-Z0-9._-]+)", data)
+
+    if res is None:
+        return None
+
+    return res.group(1).decode()
+
+
 def _get_version_from_commit(commit: str) -> str:
     url = f"https://api.github.com/search/issues?q={commit}+repo:rust-lang/rust"
     try:
@@ -64,6 +77,17 @@ def get_rustc_version(target: pathlib.Path) -> tuple[str | None, str | None]:
 
     """
     commit = get_rustc_commit(target)
+
+    version = _get_version_from_comment(target)
+
+    if commit is None and version is None:
+        return (None, None)
+
+    # version is not None, no need to continue and look it up via GitHub
+    if version:
+        log.debug(f"Found version {version} as a hardcoded string")
+        return (commit, version)
+
     if commit is None:
         return (None, None)
 

--- a/src/rustbininfo/info/compiler.py
+++ b/src/rustbininfo/info/compiler.py
@@ -28,7 +28,7 @@ def get_rustc_commit(target: pathlib.Path) -> str | None:
         if res is None:
             return None
 
-        return res.group(0)[len("rustc/") :].decode()
+        return res.group(1).decode()
 
 
 def _get_version_from_commit(commit: str) -> str:


### PR DESCRIPTION
PR #5 got me thinking about how we could figure out the rustc version for binaries made with forked Rust compilers. Then I remembered seeing that some malware authors dont strip the `.comment` section:

```
$ llvm-objdump -s --section=.comment ~/git-repos/tmp/rust-rayon/target/release/rust-rayon 

/home/gemesa/git-repos/tmp/rust-rayon/target/release/rust-rayon:	file format elf64-x86-64
Contents of section .comment:
 0000 4743433a 2028474e 55292031 342e322e  GCC: (GNU) 14.2.
 0010 31203230 32343039 31322028 52656420  1 20240912 (Red 
 0020 48617420 31342e32 2e312d33 29007275  Hat 14.2.1-3).ru
 0030 73746320 76657273 696f6e20 312e3833  stc version 1.83
 0040 2e302028 39306233 35613632 33203230  .0 (90b35a623 20
 0050 32342d31 312d3236 2900               24-11-26).
```

This section stays even if `strip` is enabled in `Cargo.toml`:

```toml
[profile.release]
strip = true
```

But it can be removed of course with different methods (see below). In this case `rbi` falls back to looking up the version based on the commit hash.

```
$ llvm-strip --strip-all ~/git-repos/tmp/rust-rayon/target/release/rust-rayon
$ llvm-objdump -s --section=.comment ~/git-repos/tmp/rust-rayon/target/release/rust-rayon

/home/gemesa/git-repos/tmp/rust-rayon/target/release/rust-rayon:	file format elf64-x86-64
llvm-objdump: warning: section '.comment' mentioned in a -j/--section option, but not found in any input file
```

This version check also works offline since the string is hardcoded in the binary.

There is an unrelated change in the PR:

```diff
-    return res.group(0)[len("rustc/") :].decode()
+    return res.group(1).decode()
```

Here `group(0)` returns the entire matched pattern including all capturing groups. `group(1)` returns only the contents of the first capturing group which is exactly what we want.